### PR TITLE
Fix incorrect definition of WORD64 and LONG64.

### DIFF
--- a/deimos/X11/Xtos.d
+++ b/deimos/X11/Xtos.d
@@ -3,12 +3,13 @@ module deimos.X11.Xtos;
 //~ #define ALLOCATE_LOCAL_FALLBACK(_size) XtMalloc((unsigned long)(_size))
 //~ #define DEALLOCATE_LOCAL_FALLBACK(_ptr) XtFree((XtPointer)(_ptr))
 //~ #include <X11/Xalloca.h>
+
+enum bool WORD64 = false;
+
 version( X86_64 ){
-    enum bool WORD64 = true;
     enum bool LONG64 = true;
 }
 else{
-    enum bool WORD64 = false;
     enum bool LONG64 = false;
 }
 /* DON'T ADD STUFF AFTER THIS #endif */


### PR DESCRIPTION
From c/X11/Xtos.h:

```
#ifdef CRAY
#define WORD64
#endif

#if defined (_LP64) || \
    defined(__alpha) || defined(__alpha__) || \
    defined(__ia64__) || defined(ia64) || \
    defined(__sparc64__) || \
    defined(__s390x__) || \
    (defined(__hppa__) && defined(__LP64__)) || \
    defined(__amd64__) || defined(amd64) || \
    defined(__powerpc64__) || \
    (defined(sgi) && (_MIPS_SZLONG == 64))
#define LONG64
#endif
```

So WORD64 should not be defined unless building on a Cray; LONG64 should be defined for other 64-bit systems.
