### PR TITLE
[Issue 23] Wrong XIValuatorState struct

### DIFF
--- a/deimos/X11/extensions/XInput2.d
+++ b/deimos/X11/extensions/XInput2.d
@@ -61,7 +61,7 @@ struct XIButtonState{
 
 struct XIValuatorState{
     int             mask_len;
-    ubyte           mask;
+    ubyte*          mask;
     double*         values;
 } 
 


### PR DESCRIPTION
This commit changes the mask field of XIValuatorState to a ubyte*, as per XInput2.h
