### PR TITLE
[Issue 30] Fix dub for executable targets.

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -4,7 +4,10 @@
     "homepage": "http://www.x.org/wiki/",
     "license": "LGPL v3",
     "sourcePaths":["."],
-    "excludedSourceFiles":["deimos/X11/Xlib_xcb.d"],
+    "excludedSourceFiles":[
+        "deimos/X11/Xlib_xcb.d",
+        "example.d"
+    ],
     "libs": ["X11"],
     "configurations":[
         {
@@ -13,7 +16,7 @@
         },
         {
             "name":"dx11-example",
-            "targetName":"dx11-example",        
+            "targetName":"dx11-example",
             "targetType":"executable",
             "sourceFiles":["example.d"]
         }


### PR DESCRIPTION
Fixes the dub.json file so example.d is not included in build for external projects.
