### PR TITLE
Issue34 carray warnings

### DIFF
--- a/deimos/X11/Xlib.d
+++ b/deimos/X11/Xlib.d
@@ -373,7 +373,7 @@ struct XKeyboardState{
     uint bell_pitch, bell_duration;
     c_ulong led_mask;
     int global_auto_repeat;
-    char auto_repeats[32];
+    char[32] auto_repeats;
 }
 
 /* Data structure for XGetMotionEvents.  */
@@ -552,7 +552,7 @@ struct XKeymapEvent{
     Bool send_event;                                    /* true if this came from a SendEvent request                   */
     Display* display;                                   /* Display the event was read from                              */
     Window window;
-    char key_vector[32];
+    char[32] key_vector;
 }
 
 struct XExposeEvent{
@@ -795,9 +795,9 @@ struct XClientMessageEvent{
     Atom message_type;
     int format;
     union _data  {
-                    char b[20];
-                    short s[10];
-                    c_long l[5];
+                    char[20] b;
+                    short[10] s;
+                    c_long[5] l;
                 }
 	_data data;
 }
@@ -896,7 +896,7 @@ struct XGenericEventCookie{
     XKeymapEvent xkeymap;
     XGenericEvent xgeneric;
     XGenericEventCookie xcookie;
-    c_long pad[24];
+    c_long[24] pad;
 };
 
 int XAllocID(Display* dpy) {return cast(int) dpy.resource_alloc(dpy);}

--- a/deimos/X11/Xlibint.d
+++ b/deimos/X11/Xlibint.d
@@ -112,12 +112,12 @@ struct _XDisplay{
                             Display*                    /* dpy                                                          */,
                             XEvent*                     /* re                                                           */,
                             xEvent*                     /* event                                                        */
-    ) event_vec[128];
+    )[128] event_vec;
     extern (C) nothrow Status function(                 /* vector for event to wire                                     */
                             Display*                    /* dpy                                                          */,
                             XEvent*                     /* re                                                           */,
                             xEvent*                     /* event                                                        */
-    ) wire_vec[128];
+    )[128] wire_vec;
     KeySym                  lock_meaning;               /* for XLookupString                                            */
     _XLockInfo*             lock;                       /* multi-thread state, display lock                             */
     _XInternalAsync*        async_handlers;             /* for internal async                                           */
@@ -174,13 +174,13 @@ struct _XDisplay{
                             Display*                    /* dpy                                                          */,
                             XGenericEventCookie*        /* Xlib event                                                   */,
                             xEvent*                     /* wire event                                                   */
-    ) generic_event_vec[128];
+    )[128] generic_event_vec;
                                                         /* vector for event copy, index is (extension - 128)            */
     extern (C) nothrow Bool function(
                             Display*                    /* dpy                                                          */,
                             XGenericEventCookie*        /* in                                                           */,
                             XGenericEventCookie*        /* out                                                          */
-    ) generic_event_copy_vec[128];
+    )[128] generic_event_copy_vec;
     void*                   cookiejar;                  /* cookie events returned but not claimed                       */
 };
 alias _XDisplay Display;

--- a/deimos/X11/Xproto.d
+++ b/deimos/X11/Xproto.d
@@ -534,7 +534,7 @@ struct xQueryKeymapReply{
     BYTE pad1;
     CARD16 sequenceNumber;
     CARD32 length;                                      /* 2, NOT 0; this is an extra-large reply                       */
-    BYTE map[32];
+    BYTE[32] map;
 }
 
                                                         /* Warning: this MUST match (up to component renaming) xListFontsWithInfoReply */
@@ -868,7 +868,7 @@ struct xGetKeyboardControlReply{
     CARD8 keyClickPercent, bellPercent;
     CARD16 bellPitch, bellDuration;
     CARD16 pad;
-    BYTE map[32];                                       /* bit masks start here                                         */
+    BYTE[32] map;                                       /* bit masks start here                                         */
 }
 
 struct xGetPointerControlReply{
@@ -1149,7 +1149,7 @@ struct _xEvent {
                 }
                 struct b{
                     Atom type;
-                    INT8 bytes[20];
+                    INT8[20] bytes;
                 }
             }
         }
@@ -1194,7 +1194,7 @@ struct xGenericEvent{
 
 struct xKeymapEvent{
     BYTE type;
-    BYTE map[31];
+    BYTE[31] map;
 }
 
 const size_t XEventSize = xEvent.sizeof;
@@ -1339,7 +1339,7 @@ struct xChangePropertyReq{
     Window window;
     Atom property, type;
     CARD8 format;
-    BYTE pad[3];
+    BYTE[3] pad;
     CARD32 nUnits;                                  /* length of stuff following, depends on format                 */
 }
 
@@ -1386,7 +1386,7 @@ version( X86_64 ){
         CARD16 length;
         Window destination;
         CARD32 eventMask;
-        BYTE eventdata[SIZEOF!xEvent()];   /* the structure should have been quad-aligned                  */
+        BYTE[SIZEOF!xEvent()] eventdata;   /* the structure should have been quad-aligned                  */
     }
 }
 else{

--- a/deimos/X11/Xregion.d
+++ b/deimos/X11/Xregion.d
@@ -144,6 +144,6 @@ const int NUMPTSTOBUFFER = 200;
  * the buffers together
  */
 struct POINTBLOCK {
-    XPoint      pts[NUMPTSTOBUFFER];
+    XPoint[NUMPTSTOBUFFER]      pts;
     POINTBLOCK* next;
 }

--- a/deimos/X11/Xresource.d
+++ b/deimos/X11/Xresource.d
@@ -120,10 +120,10 @@ alias XrmValue* XrmValuePtr;
  *
  ****************************************************************/
 struct _XrmHashBucketRec{}
-alias _XrmHashBucketRec* XrmHashBucket ;
-alias XrmHashBucket* XrmHashTable ;
-alias XrmHashTable[] XrmSearchList;
-alias _XrmHashBucketRec* XrmDatabase ;
+alias _XrmHashBucketRec*    XrmHashBucket;
+alias XrmHashBucket*        XrmHashTable;
+alias XrmHashTable[]        XrmSearchList;
+alias _XrmHashBucketRec*    XrmDatabase;
 
 
 extern void XrmDestroyDatabase(

--- a/deimos/X11/Xresource.d
+++ b/deimos/X11/Xresource.d
@@ -120,10 +120,10 @@ alias XrmValue* XrmValuePtr;
  *
  ****************************************************************/
 struct _XrmHashBucketRec{}
-alias _XrmHashBucketRec*    XrmHashBucket;
-alias XrmHashBucket*        XrmHashTable;
-alias XrmHashTable          XrmSearchList[];
-alias _XrmHashBucketRec*    XrmDatabase;
+alias _XrmHashBucketRec* XrmHashBucket ;
+alias XrmHashBucket* XrmHashTable ;
+alias XrmHashTable[] XrmSearchList;
+alias _XrmHashBucketRec* XrmDatabase ;
 
 
 extern void XrmDestroyDatabase(

--- a/deimos/X11/extensions/Xrender.d
+++ b/deimos/X11/extensions/Xrender.d
@@ -159,7 +159,7 @@ struct XTrapezoid {
 }
 
 struct XTransform {
-	XFixed  matrix[3][3];
+	XFixed[3][3]  matrix;
 }
 
 struct XFilters {


### PR DESCRIPTION
This commit should fix the compiler warnings about C-style array declarations that
have come in with DMD 2.067. I've tested on DMD 2.067-b2.