### PR TITLE
Fix signature of XQueryKeymap

### DIFF
--- a/deimos/X11/Xlib.d
+++ b/deimos/X11/Xlib.d
@@ -2863,7 +2863,7 @@ extern Bool XQueryExtension(
 
 extern int XQueryKeymap(
     Display*                                            /* display                                                      */,
-    char [32]                                           /* keys_return                                                  */
+    ref ubyte [32]                                      /* keys_return                                                  */
 );
 
 extern Bool XQueryPointer(


### PR DESCRIPTION
- Static arrays are passed by reference in C, but by value in D.
- The argument signifies a 256-bit bit-array, not a character buffer, so ubyte is more appropriate.